### PR TITLE
Priority-based override system for bone attaches based on armor equipped by actor

### DIFF
--- a/CBPSSE/ActorUtils.cpp
+++ b/CBPSSE/ActorUtils.cpp
@@ -49,57 +49,6 @@ bool actorUtils::IsActorInPowerArmor(Actor* actor) {
     return isInPowerArmor;
 }
 
-// May want to change this for any armor
-bool actorUtils::IsActorTorsoArmorEquipped(Actor* actor) {
-    bool isEquipped = false;
-    bool isArmorIgnored = false;
-
-    if (!IsActorValid(actor)) {
-        logger.Info("Actor is not valid\n");
-        return false;
-    }
-    if (!actor->equipData && !actor->equipData->slots) {
-        logger.Info("Actor has no equipData\n");
-        return false;
-    }
-
-    // 11 IS ARMOR TORSO SLOT (41 minus 30??)
-    isEquipped = actor->equipData->slots[11].item;
-
-    // Check if armor is ignored
-    if (isEquipped) {
-        if (!actor->equipData->slots[11].item) {
-            logger.Info("slot 11 item check failed.\n");
-            // redundant check but just in case
-            return false;
-        }
-        UInt32 bodyFormID;
-        if (!actor->equipData->slots[3].item) {
-            logger.Info("slot 3 item check failed.\n");
-            bodyFormID = 0;
-        }
-        else {
-            bodyFormID = actor->equipData->slots[3].item->formID;;
-        }
-        auto torsoFormID = actor->equipData->slots[11].item->formID;
-
-        //logger.Info("torsoFormID: 0x%08x\n", torsoFormID);
-        //logger.Info("bodyFormID: 0x%08x\n", bodyFormID);
-
-        auto torsoIdIter = armorIgnore.find(torsoFormID);
-
-        if (torsoIdIter != armorIgnore.end())
-            isArmorIgnored = true;
-        else if ((torsoFormID == bodyFormID - 1)) {
-            auto bodyIdIter = armorIgnore.find(bodyFormID);
-            if (bodyIdIter != armorIgnore.end())
-                isArmorIgnored = true;
-        }
-    }
-
-    return isEquipped && !isArmorIgnored;
-}
-
 bool actorUtils::IsActorTrackable(Actor* actor) {
     if (!IsActorValid(actor)) {
         logger.Info("IsActorTrackable: actor is not valid.\n");
@@ -147,4 +96,87 @@ bool actorUtils::IsBoneInWhitelist(Actor* actor, std::string boneName) {
         }
     }
     return false;
+}
+
+const actorUtils::EquippedArmor actorUtils::GetActorEquippedArmor(Actor* actor, UInt32 slot) {
+    bool isEquipped = false;
+    bool isArmorIgnored = false;
+
+    if (!actorUtils::IsActorValid(actor)) {
+        logger.Error("Actor is not valid");
+        return actorUtils::EquippedArmor{ nullptr, nullptr };
+    }
+    if (!actor->equipData && !actor->equipData->slots) {
+        logger.Error("Actor has no equipData");
+        return actorUtils::EquippedArmor{ nullptr, nullptr };
+    }
+
+    isEquipped = actor->equipData->slots[slot].item;
+
+    // Check if armor is ignored
+    if (isEquipped) {
+        if (!actor->equipData->slots[slot].item) {
+            logger.Error("slot %d item check failed.", slot);
+            // redundant check but just in case
+            return actorUtils::EquippedArmor{ nullptr, nullptr };
+        }
+        return actorUtils::EquippedArmor{ actor->equipData->slots[slot].item, actor->equipData->slots[slot].model };
+    }
+
+    return actorUtils::EquippedArmor{ nullptr, nullptr };
+}
+
+config_t actorUtils::BuildConfigForActor(Actor* actor) {
+    config_t baseConfig = config;
+
+    for (auto overrideConfigIter = configArmorOverrideMap.rbegin(); overrideConfigIter != configArmorOverrideMap.rend(); ++overrideConfigIter) {
+        auto data = overrideConfigIter->second;
+
+        std::vector<actorUtils::EquippedArmor> equippedList;
+        for (auto slot : data.slots) {
+            auto equipped = actorUtils::GetActorEquippedArmor(actor, slot);
+            if (equipped.armor && equipped.model) {
+                equippedList.push_back(equipped);
+            }
+        }
+
+        auto armorFormID = data.armors.begin();
+        for (; armorFormID != data.armors.end(); ++armorFormID) {
+            bool breakOutside = false;
+            for (auto equipped : equippedList) {
+                if (*armorFormID == equipped.armor->formID || *armorFormID == equipped.model->formID) {
+                    if (data.isWhitelist) {
+                        for (auto val : data.config) {
+                            if (data.config[val.first].empty()) {
+                                baseConfig.erase(val.first);
+                            }
+                            else {
+                                baseConfig[val.first] = val.second;
+                            }
+                        }
+                    }
+
+                    breakOutside = true;
+                    break;
+                }
+            }
+
+            if (breakOutside) {
+                break;
+            }
+        }
+
+        if (!data.isWhitelist && armorFormID == data.armors.end()) {
+            for (auto val : data.config) {
+                if (data.config[val.first].empty()) {
+                    baseConfig.erase(val.first);
+                }
+                else {
+                    baseConfig[val.first] = val.second;
+                }
+            }
+        }
+    }
+
+    return baseConfig;
 }

--- a/CBPSSE/ActorUtils.cpp
+++ b/CBPSSE/ActorUtils.cpp
@@ -106,7 +106,7 @@ const actorUtils::EquippedArmor actorUtils::GetActorEquippedArmor(Actor* actor, 
         logger.Error("Actor is not valid");
         return actorUtils::EquippedArmor{ nullptr, nullptr };
     }
-    if (!actor->equipData && !actor->equipData->slots) {
+    if (!actor->equipData || !actor->equipData->slots) {
         logger.Error("Actor has no equipData");
         return actorUtils::EquippedArmor{ nullptr, nullptr };
     }

--- a/CBPSSE/ActorUtils.h
+++ b/CBPSSE/ActorUtils.h
@@ -3,11 +3,18 @@
 #include "config.h"
 
 namespace actorUtils {
+    struct EquippedArmor {
+        const TESForm* armor;
+        const TESForm* model;
+    };
+    
     std::string GetActorRaceEID(Actor* actor);
     bool IsActorInPowerArmor(Actor* actor);
-    bool IsActorTorsoArmorEquipped(Actor* actor);
     bool IsActorMale(Actor* actor);
     bool IsActorTrackable(Actor* actor);
     bool IsActorValid(Actor* actor);
     bool IsBoneInWhitelist(Actor* actor, std::string boneName);
+
+    const EquippedArmor GetActorEquippedArmor(Actor* actor, UInt32 slot);
+    config_t BuildConfigForActor(Actor* actor);
 }

--- a/CBPSSE/config.cpp
+++ b/CBPSSE/config.cpp
@@ -14,6 +14,7 @@
 #include "f4se/GameObjects.h"
 #include "f4se/GameRTTI.h"
 #include "f4se_common/Utilities.h"
+#include "f4se/GameData.h"
 
 #define DEBUG 0
 #pragma warning(disable : 4996)
@@ -23,22 +24,69 @@ bool playerOnly = false;
 bool femaleOnly = false;
 bool maleOnly = false;
 bool npcOnly = false;
-bool detectArmor = false;
 bool useWhitelist = false;
 
 config_t config;
 config_t configArmor;
-configOverrides_t configOverrides;
-configOverrides_t configArmorOverrides;
+std::map<UInt32, armorOverrideData> configArmorOverrideMap;
 
 // TODO data structure these
 whitelist_t whitelist;
 std::vector<std::string> raceWhitelist;
-std::unordered_map<UInt32, bool> armorIgnore;
+
+UInt32 GetFormIDFromString(std::string const& configString)
+{
+    size_t colonPos = configString.find_first_of(":");
+    auto pluginFormID = configString.substr(0, colonPos);
+    std::string pluginName = "";
+    if (colonPos != std::string::npos && colonPos < configString.length() - 1) {
+        pluginName = configString.substr(colonPos + 1);
+    }
+
+    for (auto digit : pluginFormID) {
+        if (!std::isxdigit(digit)) {
+            logger.Error("Invalid FormID %s, invalid hex character %c\n", pluginFormID.c_str(), digit);
+            return -1;
+        }
+    }
+
+    UInt32 formID = std::stoul(pluginFormID, nullptr, 16);
+
+    if (!pluginName.empty()) {
+        auto dataHandler = *g_dataHandler;
+        auto modInfo = dataHandler->LookupLoadedModByName(pluginName.c_str());
+
+        if (!modInfo) {
+            logger.Error("Plugin with name %s does not exist\n", pluginName.c_str());
+            return -1;
+        }
+
+        bool isLightPlugin = modInfo->recordFlags & modInfo->kRecordFlags_ESL;
+        size_t maxPartialIdLength = isLightPlugin ? 3 : 6;
+
+        if (pluginFormID.length() > maxPartialIdLength) {
+            logger.Error("Invalid FormID %s, too many characters when%s plugin name specified\n", pluginFormID.c_str(), isLightPlugin ? " light" : "");
+            return -1;
+        }
+
+        UInt32 loadIndex = isLightPlugin ? dataHandler->GetLoadedLightModIndex(pluginName.c_str()) : dataHandler->GetLoadedModIndex(pluginName.c_str());
+        formID |= loadIndex << 24;
+    }
+    else {
+        if (pluginFormID.length() > 8) {
+            logger.Error("Invalid FormID %s, too many characters\n", pluginFormID.c_str());
+            return -1;
+        }
+    }
+
+    return formID;
+}
 
 bool LoadConfig() {
     logger.Info("loadConfig\n");
 
+    config_t configOverrides;
+    std::map<UInt32, config_t> configArmorBoneOverrides;
     std::set<std::string> bonesSet;
 
     bool reloadActors = false;
@@ -50,10 +98,7 @@ bool LoadConfig() {
 
     boneNames.clear();
     config.clear();
-    configArmor.clear();
-    configOverrides.clear();
-    configArmorOverrides.clear();
-    armorIgnore.clear();
+    configArmorOverrideMap.clear();
 
     // Note: Using INIReader results in a slight double read
     INIReader configReader("Data\\F4SE\\Plugins\\ocbp.ini");
@@ -82,26 +127,7 @@ bool LoadConfig() {
                     (npcOnly ^ npcOnlyOld) ||
                     (useWhitelist ^ useWhitelistOld);
 
-    detectArmor = configReader.GetBoolean("General", "detectArmor", false);
     configReloadCount = configReader.GetInteger("Tuning", "rate", 0);
-
-    //Read armorIgnore
-    auto armorIgnoreStr = configReader.Get("General", "armorIgnore", "");
-    {
-        size_t commaPos;
-        do {
-            commaPos = armorIgnoreStr.find_first_of(",");
-            auto token = armorIgnoreStr.substr(0, commaPos);
-            UInt32 formID;
-            std::stringstream ss;
-            ss << std::hex << token;
-            ss >> formID;
-            armorIgnore[formID] = true;
-            armorIgnoreStr = armorIgnoreStr.substr(commaPos + 1);
-
-            //logger.Info("<token:> %s, <rest:> %s, <commaPos:> %d, <colonPos:> %d\n", token.c_str(), whitelistName.c_str(), commaPos >= 0, colonPos < 0);
-        } while (commaPos != -1);
-    }
 
     // Read sections
     auto sections = configReader.Sections();
@@ -109,10 +135,16 @@ bool LoadConfig() {
 
         // Split for override section check
         auto overrideStr = std::string("Override:");
-        auto splitStr = std::mismatch(overrideStr.begin(), overrideStr.end(), sectionsIter->begin());
+        auto splitOverrideStr = std::mismatch(overrideStr.begin(), overrideStr.end(), sectionsIter->begin());
 
-        auto overrideAStr = std::string("Override.A:");
-        auto splitAStr = std::mismatch(overrideAStr.begin(), overrideAStr.end(), sectionsIter->begin());
+        auto subOverrideStr = std::string("Override.");
+        auto splitSubOverrideStr = std::mismatch(subOverrideStr.begin(), subOverrideStr.end(), sectionsIter->begin());
+
+        auto subAttachStr = std::string("Attach.");
+        auto splitSubAttachStr = std::mismatch(subAttachStr.begin(), subAttachStr.end(), sectionsIter->begin());
+
+        auto armorStr = std::string("Armor.");
+        auto splitArmorStr = std::mismatch(armorStr.begin(), armorStr.end(), sectionsIter->begin());
 
         if (*sectionsIter == std::string("Attach")) {
             // Get section contents
@@ -131,21 +163,85 @@ bool LoadConfig() {
                 }
             }
         }
-        else if (*sectionsIter == std::string("Attach.A") && detectArmor) {
-            // Get section contents
+        else if (splitSubAttachStr.first == subAttachStr.end()) {
+            auto attachSubname = std::string(splitSubAttachStr.second, sectionsIter->end());
+
+            UInt32 attachPriority;
+            try {
+                attachPriority = std::stoul(attachSubname);
+            }
+            catch (const std::exception&) {
+                continue;
+            }
+
             auto sectionMap = configReader.Section(*sectionsIter);
-            for (auto &valuesIter : sectionMap) {
-                auto &boneName = valuesIter.first;
-                auto &attachName = valuesIter.second;
+            for (auto& valuesIter : sectionMap) {
+                auto& boneName = valuesIter.first;
+                auto& attachName = valuesIter.second;
                 boneNames.push_back(boneName);
-                // Find specified bone section and insert map values into configArmor
-                if (sections.find(attachName) != sections.end()) {
+                // Find specified bone section and insert map values into config_t in configArmorOverrideMap at attachPriority
+                if (attachName.empty()) {
+                    // "Touch" the map to add empty entry for bone in config_t to signal deletion later when building config from overrides
+                    configArmorOverrideMap[attachPriority].config[boneName];
+                } 
+                else if (sections.find(attachName) != sections.end()) {
                     auto attachMapSection = configReader.Section(attachName);
-                    for (auto &attachIter : attachMapSection) {
+                    for (auto& attachIter : attachMapSection) {
                         auto& keyName = attachIter.first;
-                        configArmor[boneName][keyName] = configReader.GetFloat(attachName, keyName, 0.0);
+                        configArmorOverrideMap[attachPriority].config[boneName][keyName] = configReader.GetFloat(attachName, keyName, 0.0);
                     }
                 }
+            }
+        }
+        else if (splitArmorStr.first == armorStr.end()) {
+            auto armorSubname = std::string(splitArmorStr.second, sectionsIter->end());
+
+            UInt32 armorPriority;
+            try {
+                armorPriority = std::stoul(armorSubname);
+            }
+            catch (const std::exception&) {
+                continue;
+            }
+
+            std::string slots = configReader.Get(*sectionsIter, "slots", "");
+            if (slots.empty()) {
+                continue;
+            }
+
+            size_t commaPos;
+            do {
+                commaPos = slots.find_first_of(",");
+                auto token = slots.substr(0, commaPos);
+                slots = slots.substr(commaPos + 1);
+
+                UInt32 slot;
+                try {
+                    slot = std::stoul(token);
+                }
+                catch (const std::exception&) {
+                    continue;
+                }
+
+                configArmorOverrideMap[armorPriority].slots.emplace(slot - 30);
+            } while (commaPos != std::string::npos);
+
+            configArmorOverrideMap[armorPriority].isWhitelist = configReader.GetBoolean(*sectionsIter, "whitelist", false);
+
+            // Get section contents
+            auto sectionMap = configReader.Section(*sectionsIter);
+            for (auto& valuesIter : sectionMap) {
+                auto& key = valuesIter.first;
+                if (key == "whitelist" || key == "slots") {
+                    continue;
+                }
+
+                auto formID = GetFormIDFromString(valuesIter.second);
+                if (formID == -1) {
+                    continue;
+                }
+
+                configArmorOverrideMap[armorPriority].armors.emplace(formID);
             }
         }
         else if (*sectionsIter == std::string("Whitelist") && useWhitelist) {
@@ -185,9 +281,9 @@ bool LoadConfig() {
                 } while (commaPos != -1);
             }
         }
-        else if (splitStr.first == overrideStr.end()) {
+        else if (splitOverrideStr.first == overrideStr.end()) {
             // If section name is prefixed with "Override:", grab other half of name for bone
-            auto boneName = std::string(splitStr.second, sectionsIter->end());
+            auto boneName = std::string(splitOverrideStr.second, sectionsIter->end());
 
             // Get section contents
             auto sectionMap = configReader.Section(*sectionsIter); 
@@ -195,14 +291,26 @@ bool LoadConfig() {
                 configOverrides[boneName][valuesIt.first] = configReader.GetFloat(*sectionsIter, valuesIt.first, 0.0);
             }
         }
-        else if (splitAStr.first == overrideAStr.end()) {
-            // If section name is prefixed with "Override:", grab other half of name for bone
-            auto boneName = std::string(splitAStr.second, sectionsIter->end());
+        else if (splitSubOverrideStr.first == subOverrideStr.end()) {
+            // If section name is prefixed with "Override.", grab other half for priority and name of bone
+            auto overrideSection = std::string(splitSubOverrideStr.second, sectionsIter->end());
+
+            size_t colonPos = overrideSection.find_first_of(":");
+            auto overrideSubname = overrideSection.substr(0, colonPos);
+            auto boneName = overrideSection.substr(colonPos + 1);
+
+            UInt32 overridePriority;
+            try {
+                overridePriority = std::stoul(overrideSubname);
+            }
+            catch (const std::exception&) {
+                continue;
+            }
 
             // Get section contents
             auto sectionMap = configReader.Section(*sectionsIter);
             for (auto& valuesIt : sectionMap) {
-                configArmorOverrides[boneName][valuesIt.first] = configReader.GetFloat(*sectionsIter, valuesIt.first, 0.0);
+                configArmorBoneOverrides[overridePriority][boneName][valuesIt.first] = configReader.GetFloat(*sectionsIter, valuesIt.first, 0.0);
             }
         }
     }
@@ -217,10 +325,12 @@ bool LoadConfig() {
     }
 
     // replace armor configs with override settings (if any)
-    for (auto& boneIter : configArmorOverrides) {
-        if (configArmor.count(boneIter.first) > 0) {
-            for (auto settingIter : boneIter.second) {
-                configArmor[boneIter.first][settingIter.first] = settingIter.second;
+    for (auto conf : configArmorBoneOverrides) {
+        for (auto& boneIter : conf.second) {
+            if (configArmorOverrideMap[conf.first].config.count(boneIter.first) > 0) {
+                for (auto settingIter : boneIter.second) {
+                    configArmorOverrideMap[conf.first].config[boneIter.first][settingIter.first] = settingIter.second;
+                }
             }
         }
     }
@@ -244,13 +354,26 @@ void DumpConfigToLog()
         }
     }
 
-    logger.Info("***** ConfigArmor Dump *****\n");
-    for (auto section : configArmor) {
-        logger.Info("[%s]\n", section.first.c_str());
-        for (auto setting : section.second) {
-            logger.Info("%s=%f\n", setting.first.c_str(), setting.second);
+    logger.Info("***** ConfigArmorOverride Dump *****\n");
+        for (auto conf : configArmorOverrideMap)
+        {
+            logger.Info("** Slot-Armor Map priority %ul **\n", conf.first);
+            logger.Info("[Slots]\n");
+            for (auto slot : conf.second.slots) {
+                logger.Info("%ul\n", slot);
+            }
+            logger.Info("[Armors]\n");
+            for (auto formID : conf.second.armors) {
+                logger.Info("%ul\n", formID);
+            }
+            logger.Info("** Config priority %ul **\n", conf.first);
+            for (auto section : conf.second.config) {
+                logger.Info("[%s]\n", section.first.c_str());
+                for (auto setting : section.second) {
+                    logger.Info("%s=%f\n", setting.first.c_str(), setting.second);
+                }
+            }
         }
-    }
 }
 
 void DumpWhitelistToLog() {

--- a/CBPSSE/config.cpp
+++ b/CBPSSE/config.cpp
@@ -88,6 +88,7 @@ bool LoadConfig() {
     config_t configOverrides;
     std::map<UInt32, config_t> configArmorBoneOverrides;
     std::set<std::string> bonesSet;
+    std::unordered_map<std::string, UInt32> priorityNameMappings;
 
     bool reloadActors = false;
     auto playerOnlyOld = playerOnly;
@@ -167,11 +168,20 @@ bool LoadConfig() {
             auto attachSubname = std::string(splitSubAttachStr.second, sectionsIter->end());
 
             UInt32 attachPriority;
-            try {
-                attachPriority = std::stoul(attachSubname);
+            auto mapEntry = priorityNameMappings.find(attachSubname);
+            if (mapEntry != priorityNameMappings.end()) {
+                attachPriority = mapEntry->second;
             }
-            catch (const std::exception&) {
-                continue;
+            else {
+                std::string priorityMapping = configReader.Get("Priority", attachSubname, "");
+                try {
+                    attachPriority = std::stoul(priorityMapping);
+                }
+                catch (const std::exception&) {
+                    continue;
+                }
+
+                priorityNameMappings[attachSubname] = attachPriority;
             }
 
             auto sectionMap = configReader.Section(*sectionsIter);
@@ -197,11 +207,20 @@ bool LoadConfig() {
             auto armorSubname = std::string(splitArmorStr.second, sectionsIter->end());
 
             UInt32 armorPriority;
-            try {
-                armorPriority = std::stoul(armorSubname);
+            auto mapEntry = priorityNameMappings.find(armorSubname);
+            if (mapEntry != priorityNameMappings.end()) {
+                armorPriority = mapEntry->second;
             }
-            catch (const std::exception&) {
-                continue;
+            else {
+                std::string priorityMapping = configReader.Get("Priority", armorSubname, "");
+                try {
+                    armorPriority = std::stoul(priorityMapping);
+                }
+                catch (const std::exception&) {
+                    continue;
+                }
+
+                priorityNameMappings[armorSubname] = armorPriority;
             }
 
             std::string slots = configReader.Get(*sectionsIter, "slots", "");
@@ -300,11 +319,20 @@ bool LoadConfig() {
             auto boneName = overrideSection.substr(colonPos + 1);
 
             UInt32 overridePriority;
-            try {
-                overridePriority = std::stoul(overrideSubname);
+            auto mapEntry = priorityNameMappings.find(overrideSubname);
+            if (mapEntry != priorityNameMappings.end()) {
+                overridePriority = mapEntry->second;
             }
-            catch (const std::exception&) {
-                continue;
+            else {
+                std::string priorityMapping = configReader.Get("Priority", overrideSubname, "");
+                try {
+                    overridePriority = std::stoul(priorityMapping);
+                }
+                catch (const std::exception&) {
+                    continue;
+                }
+
+                priorityNameMappings[overrideSubname] = overridePriority;
             }
 
             // Get section contents

--- a/CBPSSE/config.h
+++ b/CBPSSE/config.h
@@ -1,5 +1,7 @@
 #pragma once
 #include <unordered_map>
+#include <unordered_set>
+#include <map>
 #include <vector>
 
 #include "f4se/GameReferences.h"
@@ -14,21 +16,26 @@ struct whitelistSex {
 
 typedef std::unordered_map<std::string, float> configEntry_t;
 typedef std::unordered_map<std::string, configEntry_t> config_t;
-typedef std::unordered_map<std::string, configEntry_t> configOverrides_t;
 typedef std::unordered_map<std::string, std::unordered_map<std::string, whitelistSex>> whitelist_t;
+
+struct armorOverrideData {
+    bool isWhitelist;
+    std::unordered_set<UInt32> slots;
+    std::unordered_set<UInt32> armors;
+    config_t config;
+};
 
 extern bool playerOnly;
 extern bool femaleOnly;
 extern bool maleOnly;
 extern bool npcOnly;
-extern bool detectArmor;
 extern bool useWhitelist;
 
 extern int configReloadCount;
 extern config_t config;
-extern config_t configArmor;
+extern std::map<UInt32, armorOverrideData> configArmorOverrideMap;
 extern whitelist_t whitelist;
 extern std::vector<std::string> raceWhitelist;
-extern std::unordered_map<UInt32, bool> armorIgnore;
+
 bool LoadConfig();
 void DumpWhitelistToLog();

--- a/CBPSSE/main.cpp
+++ b/CBPSSE/main.cpp
@@ -12,14 +12,14 @@
 
 bool RegisterFuncs(VirtualMachine* vm);
 
-PluginHandle	g_pluginHandle = kPluginHandle_Invalid;
-//F4SEMessagingInterface	* g_messagingInterface = NULL;
+PluginHandle    g_pluginHandle = kPluginHandle_Invalid;
+F4SEMessagingInterface         * g_messagingInterface = NULL;
 
-//F4SEScaleformInterface		* g_scaleform = NULL;
-//F4SESerializationInterface	* g_serialization = NULL;
-F4SETaskInterface				* g_task = nullptr;
-F4SEPapyrusInterface            * g_papyrus = nullptr;
-//IDebugLog	gLog("Data\\F4SE\\Plugins\\hook.log");
+//F4SEScaleformInterface       * g_scaleform = NULL;
+//F4SESerializationInterface   * g_serialization = NULL;
+F4SETaskInterface              * g_task = nullptr;
+F4SEPapyrusInterface           * g_papyrus = nullptr;
+//IDebugLog    gLog("Data\\F4SE\\Plugins\\hook.log");
 
 
 void DoHook();
@@ -33,6 +33,12 @@ void MessageHandler(F4SEMessagingInterface::Message * msg)
         case F4SEMessagingInterface::kMessage_GameDataReady:
         {
             logger.Info("kMessage_GameDataReady\n");
+            // Load initial config
+            logger.Error("Loading Config");
+            LoadConfig();
+            logger.Error("Hooking Game");
+            DoHook();
+            logger.Error("CBP Load Complete\n");
         }
         break;
         case F4SEMessagingInterface::kMessage_GameLoaded:
@@ -142,14 +148,16 @@ extern "C"
 
         if (g_papyrus)
             g_papyrus->Register(RegisterFuncs);
-
-        // Load initial config before the hook.
-        logger.Error("Loading Config\n");
-        LoadConfig();
-        //g_messagingInterface->RegisterListener(0, "F4SE", MessageHandler); 
-        logger.Error("Hooking Game\n");
-        DoHook();
-        logger.Error("CBP Load Complete\n");
+        
+        g_messagingInterface = (F4SEMessagingInterface*)f4se->QueryInterface(kInterface_Messaging);
+        if (!g_messagingInterface)
+        {
+            logger.Error("Couldn't get messaging interface");
+            return false;
+        }
+        
+        g_messagingInterface->RegisterListener(g_pluginHandle, "F4SE", MessageHandler); 
+        
         return true;
     }
 };

--- a/CBPSSE/scan.cpp
+++ b/CBPSSE/scan.cpp
@@ -43,9 +43,9 @@
 #pragma warning(disable : 4996)
 
 using actorUtils::IsActorMale;
-using actorUtils::IsActorTorsoArmorEquipped;
 using actorUtils::IsActorTrackable;
 using actorUtils::IsActorValid;
+using actorUtils::BuildConfigForActor;
 
 extern F4SETaskInterface *g_task;
 
@@ -208,26 +208,15 @@ void UpdateActors() {
             //logger.error("Sim Object not found in tracked actors\n");
         }
         else {
+            config_t composedConfig = BuildConfigForActor(a.actor);
+            
             auto &simObj = objIterator->second;
             if (simObj.IsBound()) {
-                // need better system for update config
-                if (IsActorTorsoArmorEquipped(a.actor) && detectArmor) {
-                    logger.Info("torso armor detected on actor %x\n", a.actor->formID);
-                    simObj.UpdateConfig(a.actor, boneNames, configArmor);
-                }
-                else {
-                    simObj.UpdateConfig(a.actor, boneNames, config);
-                }
+                simObj.UpdateConfig(a.actor, boneNames, composedConfig);
                 simObj.Update(a.actor);
             }
             else {
-                if (IsActorTorsoArmorEquipped(a.actor) && detectArmor) {
-                    logger.Info("torso armor detected on actor %x\n", a.actor->formID);
-                    simObj.Bind(a.actor, boneNames, configArmor);
-                }
-                else {
-                    simObj.Bind(a.actor, boneNames, config);
-                }
+                simObj.Bind(a.actor, boneNames, composedConfig);
             }
         }
     }


### PR DESCRIPTION
Edit: Rewritten to take into account new commit that makes reordering priorities a little less frustrating.

Replaces the old `detectArmor` config system that only worked for torso armors equipped in slot 41 to a system where any piece of armor or clothing can affect the final data given to a `Thing` object for each `SimObj` object.

This is done by altering the config file to include `Attach.NAME` and `Armor.NAME` sections and adding associated code to read and process these new sections. Overrides for these new `Attach.NAME` sections still exist in the form of `Override.NAME:BONE`. Attach remains the base that is used to build on. The `NAME`/`BONE` symbols should be replaced with the name-priority mapping and bone name respectively.

The new `Priority` section provides a way to map `NAME` mappings for following sections to a number-based priority. This section allows priorities to be reordered easier by changing values in one section rather than multiple.

The `Attach.NAME` system works by taking the base `Attach` as if it were the lowest priority and building a new `config_t` by overriding bones specified in the base with those specified in the `Attach.NAME` section when UpdateActors is called. Each `Attach.NAME` override one another based on a numbered priority where the smaller numbered priority overrides the larger. Only bones specified in each `Attach.NAME` override the prior bones, and bones given an empty value are essentially disabled unless specified again further up the chain.

New `Armor.NAME` sections dictate what equipped item will apply the associated `Attach.NAME` by linking them together if they have the same priority. The keys `whitelist` and `slots` are reserved for special use. The `whitelist` key should be set to either `0` or `1` for false or true, respectively. A value of true means that only those form ids specified should have the associated `Attach.NAME` applied when equipped, whereas a value of false means that listed form ids should NOT have the `Attach.NAME` applied. The `slots` key is a comma separated list of body slots to check against, and should have at least one slot specified. Therefore, if `whitelist` is set as false, any armor found in a slot from `slots` would have the associated `Attach.NAME` applied to it if it is not explicitly listed. This would allow the former `Attach.A` to be recreated. It should be noted, however, that actor bodies are themselves armors and so care should be taken when `whitelist` is false and `slots` contains body slots associated with the actor's body armors. Any other key can be used to specify ARMO or ARMA form ids that will be checked against in the form `xxxxxxxx`, `xxxxxx:PLUGIN`, or `xxx:LIGHTPLUGIN`. Here, `x` represents a hexidecimal digit for a form id and `PLUGIN` represents a plugin name for any plugin not marked with the ESL flag, `LIGHTPLUGIN` being the same except for those that are marked with the ESL flag. Preceeding zeroes need not be specified with each form id format and can indeed be shorter than the associated length of each string of `x` characters because of this, but not longer. Order does not matter for these armor key-value pairs.

The `Override.NAME:BONE` sections work the same as the base system by overriding specific bone config data when the config is loaded.

A partial ocbp.ini example is as follows:

```
;Mappings for priority names, allows priorities to be reordered by simply altering
;the numbers in the mappings here
[Priority]
DisabledBreast=0
UnrestrictedBreast=1
RestrictedBreast=2

;Base from which all overridden config_t are derived, essentially an [Attach.NAME]
;with a priority of infinity
[Attach]
LBreast_skin=Breast
RBreast_skin=Breast

[Attach.DisabledBreast]
LBreast_skin= ;Being empty means this bone should be "deleted"
RBreast_skin=

[Attach.UnrestrictedBreast]
LBreast_skin=Breast
RBreast_skin=Breast

[Attach.RestrictedBreast]
LBreast_skin=Breast.A
RBreast_skin=Breast.A

;All [Attach.NAME] sections define a value for LBreast_skin and RBreast_skin, so
;they will all overwrite those bones IF they are applied based on their
;associated [Armor.NAME] values

;Because this is the highest priority (lowest number defined in the Priority section) and
;applies to slot 41 and whitelist=1, it will override [Attach.RestrictedBreast] for all
;armors listed.
;The numbers used as keys have no meaning and their order has no bearing.
;The ini format just requires keys, and numbers are just used for convenience,
;they are not used or saved after being read in.
[Armor.DisabledBreast]
whitelist=1
slots=41
0=11D3C3 ;Combat Armor Torso ARMO from Fallout4.esm
1=0AF0EE:Fallout4.esm ;DC Guard Torso ARMO
2=536C4:Fallout4.esm ;Metal Torso ARMO
3=18E415:Fallout4.esm ;Raider Torso ARMO
4=187973:Fallout4.esm ;Heavy Synth Torso ARMA, only applies to Heavy Synth
                      ;Torso rather than all Synth Torso variants

;The CC Chinese Stealth Armor also occupies slot 41, [Attach.RestrictedBreast] will be
;applied. However, since [Attach.UnrestrictedBreast] overrides the same bones, it will take
;precedence over [Attach.RestrictedBreast] for this armor.
[Armor.UnrestrictedBreast]
whitelist=1
slots=33
0=F99:ccbgsfo4019-chinesestealtharmor.esl ;CC Chinese Stealth Armor

;Since whitelist=0, all equipped in slot 41 will have [Attach.RestrictedBreast] applied.
[Armor.RestrictedBreast]
whitelist=0
slots=41

;Overrides RBreast_skin values for [Attach.UnrestrictedBreast] for mirroring purposes
;Works the same as overrides from default system
[Override.UnrestrictedBreast:RBreast_skin]
rotationalX=-0.03
cogOffsetX=5.0
rotateRotationY=180.0
rotateRotationZ=180.0

;Same as above override but for [Attach.RestrictedBreast]
[Override.RestrictedBreast:RBreast_skin]
rotationalX=-0.01
rotateRotationY=180.0
rotateRotationZ=180.0
```

Attached below is a full example ocbp.ini (renamed ocbp.txt for attachment purposes), where all armor in slot 41 set apply the `Attach.A` style changes and several other armors in various slots zero out bones to disable physics.

[ocpb.txt](https://github.com/ericncream/OpenCBP_FO4/files/8987859/ocpb.txt)

